### PR TITLE
Add draft schedule

### DIFF
--- a/docs/workshop-schedule.md
+++ b/docs/workshop-schedule.md
@@ -3,5 +3,31 @@ title: Workshop Schedule
 nav_title: Schedule
 ---
 
-This workshop will take place from 12:00 - 5:00 PM EDT, Thursday August 9th and Friday August 10th.
-A full schedule is coming soon.
+This workshop will take place from 12:00 - 5:00 PM EDT, Thursday August 9th and Friday August 10th, 2023.
+A tentative schedule for the workshop is given below.
+All workshop sessions will take place over Zoom.
+
+
+| Time      | Topic                                                        |
+|===========|==============================================================|
+| **2023-08-09**  | **Using `git` and GitHub for projects**                |
+| 12:00 PM        | Welcome and Introductions                              |
+| 12:30 PM        | Introduction to `git`, Part 1                          |
+| 1:30 PM         | _Break_                                                |
+| 1:45 PM         | Introduction to `git`, Part 2: Working with branches   |
+| 2:30 PM         | _Break_                                                |
+| 2:45 PM         | `git` workflows and when to use them                   |
+| 3:15 PM         | Introduction to analytical code review, Part 1         |
+| 3:45 PM         | _Break_                                                |
+| 4:00 PM         | Tracking and planning work with GitHub                 |
+| **2023-08-10**  |  **Analytical code review in GitHub**                  |
+| 12:00 PM        | Introduction to analytical code review, Part 2         |
+| 12:45 PM        | Shared author and reviewer responsibilities            |
+| 1:30 PM         | _Break_                                                |
+| 1:45 PM         | Systems for facilitating code review                   |
+| 2:30 PM         | Pull request author resposibilities                    |
+| 3:00 PM         | _Break_                                                |
+| 3:15 PM         | Pull request reviewer resposibilities                  |
+| 3:45 PM         | From initial review to merge                           | <!-- can break during this last bit as needed, or just push through -->
+
+<!-- may end a bit early on day 2 with time for Q/A?-->


### PR DESCRIPTION
Closes #18 

This PR adds a draft schedule, following the outline in #18 but with breaks!

Questions for reviewers -  
- How do we feel about breaks? Note there are fewer breaks on day 2 since I imagine we'll end a little early (_maybe_ have some Q/A time?), but of course we can always break if/when it seems folks need a break.
- Any feedback about the amount of time for each topic? Again, this may be a little bit in flux as materials get developed, but I also hope the times in here can help to guide that development and scope of each little lesson.
- As I wrote in https://github.com/AlexsLemonade/training-admin/issues/994, to the extent that these topics need more detail, we might add that detail internally only. That said, do these titles seem about right?