### PR TITLE
Performing code review instructor notes

### DIFF
--- a/instructor-notes/pr-review.md
+++ b/instructor-notes/pr-review.md
@@ -14,10 +14,10 @@ Before the live demo, the co-instructor (i.e., instructor who is _not_ leading t
   * Show views of individual commits, and note that commit messages are helpful for review
 * Begin reviewing within GitHub, leaving the following _in-line_ comments for review:
   * In-line comment (not a suggestion)
-    * Need to set appropriate `ggplot` theme for the UMAP (no axis ticks, labels)
-  * In-line suggestions
-    * Need to set a seed (leave a suggestion)
     * Need to add a `sessionInfo()` chunk
+  * In-line suggestions
+    * Need to set a seed
+    * Need to set appropriate `ggplot` theme for the UMAP (no axis ticks, labels)
   * File-level comment
     * Need to include more markdown text contextualizing code chunks
 * Check out branch locally to run the code, during which a bug is caught because `{umap}` is not loaded into environment


### PR DESCRIPTION
This PR adds instructor notes towards #16, which entails leaving PR reviews as a live demo; this PR might actually be enough to close that issue, since we have https://github.com/AlexsLemonade/2023-chop-training-demo/issues/5 tracking next steps.

I drew on the ideas sketched out in https://github.com/AlexsLemonade/2023-chop-training-demo/issues/5 to create these instructor notes, divvying up types of comments in different places one can leave comments. 
Questions for reviewers:
- Are there other pull request views or features that I should mention here?
- I don't expect we'll have enough time to _iterate_ in review; as in, author would respond to reviews and then reviewer would come back for round to. But, I could write a section in the instructor notes for this, with a big "second half of demo time pending!" if we want to allow for that potential.

