### PR TITLE
Merge conflict live demo instructor notes

### DIFF
--- a/instructor-notes/merge-conflict.md
+++ b/instructor-notes/merge-conflict.md
@@ -48,7 +48,7 @@ geom_histogram(bins = n_bins, color = "blue")
 * Locally, checkout the `main` branch and sync up (`git switch main; git pull`)
 * Checkout the second branch: `git switch hist-mod-2`
   * Note that if we were to run `git merge main` _now_, we would avoid a merge conflict by keeping our `base` up to date before making changes in this new branch.
-  We're not going to do that for the purposes of demonstratation, but it's good to know.
+  We're not going to do that for the purposes of demonstration, but it's good to know.
 * Modify the histogram code to induce a conflict:
 ```r
 # original code


### PR DESCRIPTION
This PR adds instructor notes for demonstrating merge conflicts as part of #17 

The scenarios I created are pretty simple but hopefully effective! I also made some simplifying choices (e.g., not-so-good branch names, lack of good code review during PR approval...) to prioritize making the demo easier to follow; better practices are highlighted in other areas of the workshop, and the instructor presenting should explain that the simplifying choices are _just_ for the sake of the demo! I'll note the histograms getting created here probably are ugly, but that's probably ok... Note also for this demo, we have to make all branches at once in the beginning to ensure we have an out-of-date base for the latter 2 branches with conflicts.

I'd appreciate feedback in particular about the specific approaches I've used to a) realize that merge conflicts are present (first via PR, then via CLI merge), and b) resolve the merge conflicts. Would you add anything here? Let me know if any steps should be expanded or condensed overall! 