### PR TITLE
Update schedule

### DIFF
--- a/docs/workshop-schedule.md
+++ b/docs/workshop-schedule.md
@@ -40,7 +40,7 @@ All workshop sessions will take place over Zoom.
 | 2:15 PM         | _Break_                                                |              |
 | 2:30 PM         | Stacking branches and using forks                      | Stephanie    |
 |                 | Slides:                                                |              |
-| 3:15 PM         | Pull request reviewer responsibilities                 |              |
+| 3:15 PM         | Pull request reviewer responsibilities                 | Jaclyn       |
 |                 | Slides:                                                |              |
 | 3:30 PM         | _Break_                                                |              |
 | 3:45 PM         | Performing and responding to code review               | Stephanie    |


### PR DESCRIPTION
Following our discussion, I've updated the schedule. This will hopefully also help a bit, logistically, towards #20 to ensure we've included all the slides that need to be included.

Good places to check:
- Pretty much everything is slotted for 30 min except:
  - intro git is an hour, branches is 45 min
  - stacking is 45 minutes. I don't necessarily have a specific reason for this being longer though besides filling time before another break... Either way, it'll go how it goes and I'm confident will be in the overall time! It's always hard to predict.
- How do breaks look now?
- Is the instructor column overkill? I think it's useful, but honestly mostly for us, which maybe isn't bad either? If we don't want that to be forward facing though, I can maybe add to our internal schedule.